### PR TITLE
fix(transfer): update transfer request logic to include origin school

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "copyfiles": "^2.4.1",
-    "dhis2-semis-components": "0.6.8-alpha.24",
+    "dhis2-semis-components": "0.6.8-alpha.25",
     "dhis2-semis-functions": "0.0.7-alpha.56",
     "dhis2-semis-types": "1.3.24",
     "eslint": "^8.57.1",

--- a/src/components/modal/requestTransferModa.tsx
+++ b/src/components/modal/requestTransferModa.tsx
@@ -16,7 +16,8 @@ export default function RequestTransferModal({ open, setOpen, selected, setSelec
 
     async function onSubmit(values: any) {
         setLoading(true)
-        const dataElementsToPost = dataElements?.filter(x => x.id !== transfer.status)
+        const dataElementsToPost = dataElements?.filter(x => x.id !== transfer.status && x.id !== transfer.originSchool)
+
         let proceed = true, dataElementsValues = []
 
         for (let dataElement of dataElementsToPost)
@@ -38,7 +39,9 @@ export default function RequestTransferModal({ open, setOpen, selected, setSelec
                         trackedEntityInstance: event?.trackedEntity,
                         dataValues: [
                             ...dataElementsValues,
-                            { dataElement: transfer.status, value: 'Pending' }
+                            { dataElement: transfer.status, value: 'Pending' },
+                            { dataElement: transfer.originSchool, value: school }
+
                         ]
                     })
             }
@@ -89,7 +92,7 @@ export default function RequestTransferModal({ open, setOpen, selected, setSelec
                                             storyBook: false,
                                             name: "Perform transfer",
                                             description: "Select the destination school",
-                                            fields: dataElements?.filter(x => x.id !== transfer.status)
+                                            fields: dataElements?.filter(x => x.id !== transfer.status && x.id !== transfer?.originSchool)
                                         }
                                     ]}
                                     storyBook={false}

--- a/src/pages/trasferExecute/TransferExecute.tsx
+++ b/src/pages/trasferExecute/TransferExecute.tsx
@@ -45,6 +45,7 @@ const TransferExecute = () => {
     setPagination((prev: any) => ({ ...prev, totalPages: tableData?.pagination?.totalPages, totalElements: tableData?.pagination?.totalElements }))
   }, [tableData])
 
+  console.log(tableData)
   return (
     <div style={{ height: "85vh" }}>
       {!(Boolean(schoolName) && Boolean(school)) ? (


### PR DESCRIPTION
The transfer request modal now properly filters out both status and origin school data elements when submitting a transfer request. Also adds origin school value to the data values being posted.