### PR TITLE
fix(requestTransferModal): validate only required fields before submission

### DIFF
--- a/src/components/modal/requestTransferModa.tsx
+++ b/src/components/modal/requestTransferModa.tsx
@@ -22,7 +22,7 @@ export default function RequestTransferModal({ i18n, open, setOpen, selected, se
         let proceed = true, dataElementsValues = []
 
         for (let dataElement of dataElementsToPost)
-            if (!values[dataElement.id]) proceed = false
+            if (!values[dataElement.id] && dataElement?.required) proceed = false
             else dataElementsValues.push({ dataElement: dataElement.id, value: values[dataElement.id] })
 
         if (proceed) {
@@ -61,6 +61,7 @@ export default function RequestTransferModal({ i18n, open, setOpen, selected, se
                 })
                 .catch(() => { setLoading(false); setOpen(false) })
         } else {
+            setLoading(true)
             show({
                 message: i18n.t(`Please fill all required fields`),
                 type: { warning: true }
@@ -69,6 +70,7 @@ export default function RequestTransferModal({ i18n, open, setOpen, selected, se
         }
     }
 
+    console.log(dataElements)
     return (
         <ModalComponent
             open={open}

--- a/src/components/modal/requestTransferModa.tsx
+++ b/src/components/modal/requestTransferModa.tsx
@@ -61,7 +61,7 @@ export default function RequestTransferModal({ i18n, open, setOpen, selected, se
                 })
                 .catch(() => { setLoading(false); setOpen(false) })
         } else {
-            setLoading(true)
+            setLoading(false)
             show({
                 message: i18n.t(`Please fill all required fields`),
                 type: { warning: true }
@@ -70,7 +70,6 @@ export default function RequestTransferModal({ i18n, open, setOpen, selected, se
         }
     }
 
-    console.log(dataElements)
     return (
         <ModalComponent
             open={open}


### PR DESCRIPTION
Only check required data elements when validating form fields to prevent false validation failures. Show error message only when required fields are missing, and ensure loading state is properly set during validation.